### PR TITLE
Mobile Editor View

### DIFF
--- a/apps/client/src/AppRouter.tsx
+++ b/apps/client/src/AppRouter.tsx
@@ -19,6 +19,7 @@ import { ONTIME_VERSION } from './ONTIME_VERSION';
 import { sentryDsn, sentryRecommendedIgnore } from './sentry.config';
 
 const Editor = React.lazy(() => import('./features/editors/ProtectedEditor'));
+const MobileEditor = React.lazy(() => import('./features/editors/ProtectedMobileEditor'));
 const Cuesheet = React.lazy(() => import('./views/cuesheet/ProtectedCuesheet'));
 const Operator = React.lazy(() => import('./features/operator/OperatorExport'));
 
@@ -157,6 +158,7 @@ export default function AppRouter() {
 
         {/*/!* Protected Routes *!/*/}
         <Route path='/editor' element={<Editor />} />
+        <Route path='/mobile-editor' element={<MobileEditor />} />
         <Route path='/cuesheet' element={<PCuesheet />} />
         <Route
           path='/op'

--- a/apps/client/src/common/components/navigation-menu/NavigationMenu.tsx
+++ b/apps/client/src/common/components/navigation-menu/NavigationMenu.tsx
@@ -100,6 +100,14 @@ function NavigationMenu(props: NavigationMenuProps) {
               <IoLockClosedOutline />
               Editor
             </Link>
+            <Link
+              to='/mobile-editor'
+              tabIndex={0}
+              className={`${style.link} ${location.pathname === '/mobile-editor' && style.current}`}
+            >
+              <IoLockClosedOutline />
+              Mobile Editor
+            </Link>
             <ClientLink to='cuesheet' current={location.pathname === '/cuesheet'}>
               <IoLockClosedOutline />
               Cuesheet

--- a/apps/client/src/features/control/playback/MobileTimerControlExport.tsx
+++ b/apps/client/src/features/control/playback/MobileTimerControlExport.tsx
@@ -1,0 +1,20 @@
+import { memo } from 'react';
+
+import ErrorBoundary from '../../../common/components/error-boundary/ErrorBoundary';
+
+import style from '../../editors/Editor.module.scss';
+import PlaybackControl from './PlaybackControl';
+
+const MobileTimerControlExport = () => {
+  return (
+    <div className={style.playback} data-testid='panel-timer-control'>
+      <div className={style.content}>
+        <ErrorBoundary>
+          <PlaybackControl />
+        </ErrorBoundary>
+      </div>
+    </div>
+  );
+};
+
+export default memo(MobileTimerControlExport);

--- a/apps/client/src/features/editors/MobileEditor.tsx
+++ b/apps/client/src/features/editors/MobileEditor.tsx
@@ -1,0 +1,69 @@
+import { lazy, useEffect } from 'react';
+import { IoApps } from 'react-icons/io5';
+import { IconButton, useDisclosure } from '@chakra-ui/react';
+import { useHotkeys } from '@mantine/hooks';
+
+import NavigationMenu from '../../common/components/navigation-menu/NavigationMenu';
+import { useElectronListener } from '../../common/hooks/useElectronEvent';
+import { useWindowTitle } from '../../common/hooks/useWindowTitle';
+import useAppSettingsNavigation from '../app-settings/useAppSettingsNavigation';
+
+import styles from './Editor.module.scss';
+import rundownStyle from '../rundown/RundownExport.module.scss';
+import { MobileEditorOverview } from '../overview/MobileOverview';
+import { ErrorBoundary } from '@sentry/react';
+
+const MobileTimerControl = lazy(() => import('../control/playback/MobileTimerControlExport'));
+const MobileRundown = lazy(() => import('../rundown/MobileRundownExport'));
+const MobileRundownEventEditor = lazy(() => import('../rundown/event-editor/MobileRundownEventEditor'));
+export default function MobileEditor() {
+  const { setLocation } = useAppSettingsNavigation();
+  const { isOpen: isMenuOpen, onOpen, onClose } = useDisclosure();
+  const { onToggle: onFinderToggle, onClose: onFinderClose } = useDisclosure();
+
+  useWindowTitle('Mobile Editor');
+
+  // we need to register the listener to change the editor location
+  useElectronListener();
+
+  // listen to shutdown request from electron process
+  useEffect(() => {
+    if (window.process?.type === 'renderer') {
+      window.ipcRenderer.on('user-request-shutdown', () => {
+        setLocation('shutdown');
+      });
+    }
+  }, [setLocation]);
+
+
+  useHotkeys([
+    ['mod + f', onFinderToggle],
+    ['Escape', onFinderClose],
+  ]);
+
+  return (
+    <div className={styles.mainContainer} data-testid='event-editor'>
+      <NavigationMenu isOpen={isMenuOpen} onClose={onClose} />
+      <MobileEditorOverview>
+        <IconButton
+          aria-label='Toggle navigation'
+          variant='ontime-subtle-white'
+          size='lg'
+          icon={<IoApps />}
+          onClick={onOpen}
+        />
+      </MobileEditorOverview>
+      <div id='panels' className={styles.panelContainer}>
+        <div className={styles.left}>
+          <MobileTimerControl />
+          <div className={rundownStyle.side}>
+            <ErrorBoundary>
+              <MobileRundownEventEditor />
+            </ErrorBoundary>
+          </div>
+        </div>
+        <MobileRundown />
+      </div>
+    </div>
+  );
+}

--- a/apps/client/src/features/editors/ProtectedMobileEditor.tsx
+++ b/apps/client/src/features/editors/ProtectedMobileEditor.tsx
@@ -1,0 +1,11 @@
+import ProtectRoute from '../../common/components/protect-route/ProtectRoute';
+
+import MobileEditor from './MobileEditor';
+
+export default function ProtectedMobileEditor() {
+  return (
+    <ProtectRoute permission='editor'>
+      <MobileEditor />
+    </ProtectRoute>
+  );
+}

--- a/apps/client/src/features/overview/MobileOverview.tsx
+++ b/apps/client/src/features/overview/MobileOverview.tsx
@@ -1,0 +1,147 @@
+import { memo, PropsWithChildren, ReactNode, useMemo } from 'react';
+import { millisToString } from 'ontime-utils';
+
+import ErrorBoundary from '../../common/components/error-boundary/ErrorBoundary';
+import { useIsOnline, useRuntimeOverview, useRuntimePlaybackOverview, useTimer } from '../../common/hooks/useSocket';
+import useProjectData from '../../common/hooks-query/useProjectData';
+import { cx, enDash, timerPlaceholder } from '../../common/utils/styleUtils';
+
+import { TimeColumn, TimeRow } from './composite/TimeLayout';
+import { calculateEndAndDaySpan, formatedTime, getOffsetText } from './overviewUtils';
+
+import style from './Overview.module.scss';
+
+export const MobileEditorOverview = memo(_MobileEditorOverview);
+
+function _MobileEditorOverview({ children }: PropsWithChildren) {
+  const { plannedEnd, expectedEnd } = useRuntimeOverview();
+
+  const [maybePlannedEnd, maybePlannedDaySpan] = useMemo(() => calculateEndAndDaySpan(plannedEnd), [plannedEnd]);
+  const plannedEndText = formatedTime(maybePlannedEnd);
+
+  const [maybeExpectedEnd, maybeExpectedDaySpan] = useMemo(() => calculateEndAndDaySpan(expectedEnd), [expectedEnd]);
+  const expectedEndText = formatedTime(maybeExpectedEnd);
+
+  return (
+    <OverviewWrapper navElements={children}>
+      <TitlesOverview />
+      <ProgressOverview />
+      <RuntimeOverview />
+      <div>
+        <TimeRow
+          label='Planned end'
+          value={plannedEndText}
+          className={style.end}
+          daySpan={maybePlannedDaySpan}
+          muted={maybePlannedEnd === null}
+        />
+        <TimeRow
+          label='Expected end'
+          value={expectedEndText}
+          className={style.end}
+          daySpan={maybeExpectedDaySpan}
+          muted={maybeExpectedEnd === null}
+        />
+      </div>
+    </OverviewWrapper>
+  );
+}
+
+export const MobileCuesheetOverview = memo(_MobileCuesheetOverview);
+
+function _MobileCuesheetOverview({ children }: PropsWithChildren) {
+  const { plannedEnd, expectedEnd } = useRuntimeOverview();
+
+  const [maybePlannedEnd, maybePlannedDaySpan] = useMemo(() => calculateEndAndDaySpan(plannedEnd), [plannedEnd]);
+  const plannedEndText = formatedTime(maybePlannedEnd);
+
+  const [maybeExpectedEnd, maybeExpectedDaySpan] = useMemo(() => calculateEndAndDaySpan(expectedEnd), [expectedEnd]);
+  const expectedEndText = formatedTime(maybeExpectedEnd);
+
+  return (
+    <OverviewWrapper navElements={children}>
+      <TitlesOverview />
+      <TimerOverview />
+      <RuntimeOverview />
+      <div>
+        <TimeRow
+          label='Planned end'
+          value={plannedEndText}
+          className={style.end}
+          daySpan={maybePlannedDaySpan}
+          muted={maybePlannedEnd === null}
+        />
+        <TimeRow
+          label='Expected end'
+          value={expectedEndText}
+          className={style.end}
+          daySpan={maybeExpectedDaySpan}
+          muted={maybeExpectedEnd === null}
+        />
+      </div>
+    </OverviewWrapper>
+  );
+}
+
+interface OverviewWrapperProps {
+  navElements: ReactNode;
+}
+
+function OverviewWrapper({ navElements, children }: PropsWithChildren<OverviewWrapperProps>) {
+  const { isOnline } = useIsOnline();
+  return (
+    <div className={cx([style.overview, !isOnline && style.isOffline])}>
+      <ErrorBoundary>
+        <div className={style.nav}>{navElements}</div>
+        <div className={style.info}>{children}</div>
+      </ErrorBoundary>
+    </div>
+  );
+}
+
+function TitlesOverview() {
+  const { data } = useProjectData();
+
+  if (!data.title && !data.description) {
+    return null;
+  }
+
+  return (
+    <div>
+      <div className={style.title}>{data.title}</div>
+      <div className={style.description}>{data.description}</div>
+    </div>
+  );
+}
+
+function TimerOverview() {
+  const { current } = useTimer();
+
+  const display = millisToString(current, { fallback: timerPlaceholder });
+
+  return <TimeColumn label='Running timer' value={display} muted={current === null} />;
+}
+
+function ProgressOverview() {
+  const { numEvents, selectedEventIndex } = useRuntimePlaybackOverview();
+
+  const current = selectedEventIndex !== null ? selectedEventIndex + 1 : enDash;
+  const ofTotal = numEvents || enDash;
+  const progressText = numEvents ? `${current} of ${ofTotal}` : '-';
+
+  return <TimeColumn label='Progress' value={progressText} />;
+}
+
+function RuntimeOverview() {
+  const { clock, offset } = useRuntimePlaybackOverview();
+
+  const offsetText = getOffsetText(offset);
+  const offsetClasses = offset === null ? undefined : offset <= 0 ? style.behind : style.ahead;
+
+  return (
+    <>
+      <TimeColumn label='Offset' value={offsetText} className={offsetClasses} testId='offset' />
+      <TimeColumn label='Time now' value={formatedTime(clock)} />
+    </>
+  );
+}

--- a/apps/client/src/features/rundown/MobileRundownExport.tsx
+++ b/apps/client/src/features/rundown/MobileRundownExport.tsx
@@ -1,0 +1,29 @@
+import { memo } from 'react';
+
+import { ContextMenu } from '../../common/components/context-menu/ContextMenu';
+import ErrorBoundary from '../../common/components/error-boundary/ErrorBoundary';
+import { cx } from '../../common/utils/styleUtils';
+
+import RundownWrapper from './RundownWrapper';
+
+import style from './RundownExport.module.scss';
+
+const MobileRundownExport = () => {
+  const classes = cx([style.rundownExport]);
+
+  return (
+    <div className={classes} data-testid='panel-rundown'>
+      <div className={style.rundown}>
+        <div className={style.list}>
+          <ErrorBoundary>
+            <ContextMenu>
+              <RundownWrapper />
+            </ContextMenu>
+          </ErrorBoundary>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default memo(MobileRundownExport);

--- a/apps/client/src/features/rundown/event-editor/MobileEventEditor.tsx
+++ b/apps/client/src/features/rundown/event-editor/MobileEventEditor.tsx
@@ -1,0 +1,39 @@
+import { CustomFieldLabel, OntimeEvent } from 'ontime-types';
+
+import EventEditorEmpty from './EventEditorEmpty';
+
+import style from './EventEditor.module.scss';
+import MobileEventEditorTimes from './composite/MobileEventEditorTimes';
+
+export type EventEditorSubmitActions = keyof OntimeEvent;
+
+export type EditorUpdateFields = 'cue' | 'title' | 'note' | 'colour' | CustomFieldLabel;
+
+interface EventEditorProps {
+  event: OntimeEvent;
+}
+
+export default function MobileEventEditor(props: EventEditorProps) {
+  const { event } = props;
+
+  if (!event) {
+    return <EventEditorEmpty />;
+  }
+
+  return (
+    <div className={style.content}>
+      <MobileEventEditorTimes
+        key={`${event.id}-times`}
+        eventId={event.id}
+        timeStart={event.timeStart}
+        timeEnd={event.timeEnd}
+        duration={event.duration}
+        timeStrategy={event.timeStrategy}
+        linkStart={event.linkStart}
+        countToEnd={event.countToEnd}
+        delay={event.delay ?? 0}
+        endAction={event.endAction}
+      />
+    </div>
+  );
+}

--- a/apps/client/src/features/rundown/event-editor/MobileRundownEventEditor.tsx
+++ b/apps/client/src/features/rundown/event-editor/MobileRundownEventEditor.tsx
@@ -1,0 +1,52 @@
+import { memo, useEffect, useState } from 'react';
+import { isOntimeEvent, OntimeEvent } from 'ontime-types';
+
+import useRundown from '../../../common/hooks-query/useRundown';
+import { useEventSelection } from '../useEventSelection';
+
+import { EventEditorFooter } from './composite/EventEditorFooter';
+import EventEditorEmpty from './EventEditorEmpty';
+import MobileEventEditor from './MobileEventEditor';
+
+import style from './EventEditor.module.scss';
+
+function MobileRundownEventEditor() {
+  const selectedEvents = useEventSelection((state) => state.selectedEvents);
+  const { data } = useRundown();
+  const { order, rundown } = data;
+
+  const [event, setEvent] = useState<OntimeEvent | null>(null);
+
+  useEffect(() => {
+    if (order.length === 0) {
+      setEvent(null);
+      return;
+    }
+
+    const selectedEventId = order.find((eventId) => selectedEvents.has(eventId));
+    if (!selectedEventId) {
+      setEvent(null);
+      return;
+    }
+    const event = rundown[selectedEventId];
+
+    if (event && isOntimeEvent(event)) {
+      setEvent(event);
+    } else {
+      setEvent(null);
+    }
+  }, [order, rundown, selectedEvents]);
+
+  if (!event) {
+    return <EventEditorEmpty />;
+  }
+
+  return (
+    <div className={style.eventEditor} data-testid='editor-container'>
+      <MobileEventEditor event={event} />
+      <EventEditorFooter id={event.id} cue={event.cue} />
+    </div>
+  );
+}
+
+export default memo(MobileRundownEventEditor);

--- a/apps/client/src/features/rundown/event-editor/composite/MobileEventEditorTimes.tsx
+++ b/apps/client/src/features/rundown/event-editor/composite/MobileEventEditorTimes.tsx
@@ -1,0 +1,120 @@
+import { memo } from 'react';
+import { Select, Switch } from '@chakra-ui/react';
+import { EndAction, MaybeString, TimeStrategy } from 'ontime-types';
+import { millisToString } from 'ontime-utils';
+
+import { useEventAction } from '../../../../common/hooks/useEventAction';
+import { millisToDelayString } from '../../../../common/utils/dateConfig';
+import * as Editor from '../../../editors/editor-utils/EditorUtils';
+import TimeInputFlow from '../../time-input-flow/TimeInputFlow';
+
+import style from '../EventEditor.module.scss';
+
+interface MobileEventEditorTimesProps {
+  eventId: string;
+  timeStart: number;
+  timeEnd: number;
+  duration: number;
+  timeStrategy: TimeStrategy;
+  linkStart: MaybeString;
+  countToEnd: boolean;
+  delay: number;
+  endAction: EndAction;
+}
+
+type HandledActions = 'countToEnd' | 'endAction';
+
+function MobileEventEditorTimes(props: MobileEventEditorTimesProps) {
+  const {
+    eventId,
+    timeStart,
+    timeEnd,
+    duration,
+    timeStrategy,
+    linkStart,
+    countToEnd,
+    delay,
+    endAction,
+  } = props;
+  const { updateEvent } = useEventAction();
+
+  const handleSubmit = (field: HandledActions, value: string | boolean) => {
+    if (field === 'countToEnd') {
+      updateEvent({ id: eventId, countToEnd: !(value as boolean) });
+      return;
+    }
+
+    if (field === 'endAction') {
+      updateEvent({ id: eventId, endAction: value as EndAction });
+      return;
+    }
+  };
+
+  const hasDelay = delay !== 0;
+  const delayLabel = hasDelay
+    ? `Event is ${millisToDelayString(delay, 'expanded')}. New schedule ${millisToString(
+        timeStart + delay,
+      )} → ${millisToString(timeEnd + delay)}`
+    : '';
+
+  return (
+    <>
+      <div className={style.column}>
+        <Editor.Title>Event schedule</Editor.Title>
+        <div>
+          <div className={style.inline}>
+            <TimeInputFlow
+              eventId={eventId}
+              timeStart={timeStart}
+              timeEnd={timeEnd}
+              duration={duration}
+              timeStrategy={timeStrategy}
+              linkStart={linkStart}
+              delay={delay}
+              countToEnd={countToEnd}
+              showLabels
+            />
+          </div>
+          <div className={style.delayLabel}>{delayLabel}</div>
+        </div>
+      </div>
+
+      <div className={style.column}>
+        <Editor.Title>Event Behaviour</Editor.Title>
+        <div className={style.splitTwo}>
+          <div>
+            <Editor.Label htmlFor='endAction'>End Action</Editor.Label>
+            <Select
+              id='endAction'
+              size='sm'
+              name='endAction'
+              value={endAction}
+              onChange={(event) => handleSubmit('endAction', event.target.value)}
+              variant='ontime'
+            >
+              <option value={EndAction.None}>None</option>
+              <option value={EndAction.Stop}>Stop rundown</option>
+              <option value={EndAction.LoadNext}>Load next event</option>
+              <option value={EndAction.PlayNext}>Play next event</option>
+            </Select>
+          </div>
+          <div>
+            <Editor.Label htmlFor='countToEnd'>Count to End</Editor.Label>
+            <Editor.Label className={style.switchLabel}>
+              <Switch
+                id='countToEnd'
+                size='md'
+                isChecked={countToEnd}
+                onChange={() => handleSubmit('countToEnd', countToEnd)}
+                variant='ontime'
+              />
+              {countToEnd ? 'On' : 'Off'}
+            </Editor.Label>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}
+
+export default memo(MobileEventEditorTimes);


### PR DESCRIPTION
First Pass at a mobile editor view.

Works in either the Ontime app,
<img width="1511" alt="image" src="https://github.com/user-attachments/assets/f03f9325-c8e3-488d-9838-3b3affdb93f7" />
or via the web portal
![image](https://github.com/user-attachments/assets/4764db01-7a64-4208-bbc7-aebf11200476)

Full View (without the nav-bar in the way)
![image](https://github.com/user-attachments/assets/9670e394-c359-418f-b40b-2f2612689717)
![image](https://github.com/user-attachments/assets/705b3fb2-afe9-4a69-834b-0c426813dc28)

To access:
Click on the 'Mobile Editor' entry in the nav-bar

Changes:
- Added 'Mobile Editor' page to protected Editor routes
(The below changes only apply to the new 'Mobile Editor')
- Removed the 'Settings' button from the top 'Overview'
- Removed the 'expanded' icons from Playback control and Rundown 
- Moved 'RundownEventEditor' to under the 'Playback' control
- Removed several properties from the 'MobileRundownEventEditor' 

TODO:
- [ ] Add tests 
- [ ] Fix styling
  - [ ] 'Rundown' doesn't expand to fill width
  - [ ] 'EventEditorEmpty' settings labels wrap weirdly
  - [ ] 'MobileEventEditor' doesn't have border radius on left-hand side
  - [ ] Make styling more responsive overall
- [ ] Investigate PIN number protection
- [ ] Test on an actual iPad
- [ ] Add the title of the event being edited to the top of the 'MobileEventEditor'

Longer term, I'd like to move this to a more configuration based approach, allowing the user to create and manage editor views (What widgets are displayed on the editor, where they display, and what they display). However, this serves as a working proof-of-concept, to demonstrate the idea, and gather initial feedback