### PR TITLE
Invert time-linking model — edit start to stretch previous event

### DIFF
--- a/apps/client/src/common/hooks/useEventAction.ts
+++ b/apps/client/src/common/hooks/useEventAction.ts
@@ -11,7 +11,7 @@ import {
   TimeStrategy,
   TransientEventPayload,
 } from 'ontime-types';
-import { dayInMs, MILLIS_PER_SECOND, parseUserTime, reorderArray, swapEventData } from 'ontime-utils';
+import { calculateDuration, dayInMs, MILLIS_PER_SECOND, parseUserTime, reorderArray, swapEventData } from 'ontime-utils';
 
 import { RUNDOWN } from '../api/constants';
 import {
@@ -241,6 +241,36 @@ export const useEventAction = () => {
         return;
       }
 
+      // Inverted linked-start model: editing a LINKED event's start stretches the previous
+      // event — its end moves to the new start and its duration absorbs the change. The
+      // forward-cascade engine then re-derives this event's start from the previous end.
+      // Unlinked events and the first event in the chain edit their own start (fall through).
+      if (!lockOnUpdate && field === 'timeStart') {
+        const cachedRundown = queryClient.getQueryData<RundownCached>(RUNDOWN);
+        const targetEvent = cachedRundown?.rundown[eventId];
+        if (isOntimeEvent(targetEvent) && targetEvent.linkStart) {
+          const previous = getPrevious();
+          if (previous) {
+            const newStart = calculateNewValue();
+            // can't move the previous event's end before its own start
+            if (newStart <= previous.timeStart) {
+              return;
+            }
+            try {
+              await _updateEventMutation.mutateAsync({
+                id: previous.id,
+                timeStrategy: TimeStrategy.LockDuration,
+                duration: calculateDuration(previous.timeStart, newStart),
+              });
+            } catch (error) {
+              logAxiosError('Error updating event', error);
+            }
+            return;
+          }
+          // first event in the chain (no previous): fall through to self-edit below
+        }
+      }
+
       const newEvent: Partial<OntimeEvent> = {
         id: eventId,
       };
@@ -293,28 +323,34 @@ export const useEventAction = () => {
       }
 
       /**
-       * Utility function to get the previous event end time
+       * Utility function to get the previous playable (non-skipped) event.
+       * Matches the server's getLink so the client stretches the same event the server links to.
        */
-      function getPreviousEnd(): number {
+      function getPrevious(): OntimeEvent | null {
         const cachedRundown = queryClient.getQueryData<RundownCached>(RUNDOWN);
 
         if (!cachedRundown?.order || !cachedRundown?.rundown) {
-          return 0;
+          return null;
         }
 
         const index = cachedRundown.order.indexOf(eventId);
-        if (index === 0) {
-          return 0;
+        if (index <= 0) {
+          return null;
         }
-        let previousEnd = 0;
         for (let i = index - 1; i >= 0; i--) {
           const event = cachedRundown.rundown[cachedRundown.order[i]];
-          if (isOntimeEvent(event)) {
-            previousEnd = event.timeEnd;
-            break;
+          if (isOntimeEvent(event) && !event.skip) {
+            return event;
           }
         }
-        return previousEnd;
+        return null;
+      }
+
+      /**
+       * Utility function to get the previous event end time
+       */
+      function getPreviousEnd(): number {
+        return getPrevious()?.timeEnd ?? 0;
       }
     },
     [_updateEventMutation, queryClient],

--- a/apps/client/src/features/rundown/time-input-flow/IpadTimeInputFlow.tsx
+++ b/apps/client/src/features/rundown/time-input-flow/IpadTimeInputFlow.tsx
@@ -1,5 +1,5 @@
 import { memo } from 'react';
-import { IoAlertCircleOutline, IoLink, IoLockClosed, IoLockOpenOutline, IoUnlink } from 'react-icons/io5';
+import { IoAlertCircleOutline, IoLockClosed, IoLockOpenOutline } from 'react-icons/io5';
 import { InputRightElement, Tooltip } from '@chakra-ui/react';
 import { MaybeString, TimeField, TimeStrategy } from 'ontime-types';
 import { dayInMs } from 'ontime-utils';
@@ -25,7 +25,7 @@ interface IpadTimeInputFlowProps {
 }
 
 function IpadTimeInputFlow(props: IpadTimeInputFlowProps) {
-  const { eventId, timeStart, duration, timeStrategy, linkStart, delay, showLabels } = props;
+  const { eventId, timeStart, duration, timeStrategy, delay, showLabels } = props;
   const { updateEvent, updateTimer } = useEventAction();
   const displayStart = timeStart + delay;
 
@@ -37,10 +37,6 @@ function IpadTimeInputFlow(props: IpadTimeInputFlowProps) {
     updateEvent({ id: eventId, timeStrategy: newStrategy });
   };
 
-  const handleLink = (doLink: boolean) => {
-    updateEvent({ id: eventId, linkStart: doLink ? 'true' : null });
-  };
-
   const warnings = [];
   if (timeStart + duration > dayInMs) {
     warnings.push('Over midnight');
@@ -48,7 +44,6 @@ function IpadTimeInputFlow(props: IpadTimeInputFlowProps) {
 
   const hasDelay = delay !== 0;
   const isLockedDuration = timeStrategy === TimeStrategy.LockDuration;
-  const activeStart = cx([style.timeAction, linkStart ? style.active : null]);
   const activeDuration = cx([style.timeAction, isLockedDuration ? style.active : null]);
 
   return (
@@ -63,12 +58,9 @@ function IpadTimeInputFlow(props: IpadTimeInputFlowProps) {
           hasDelay={hasDelay}
           placeholder='Start'
         >
-          <Tooltip label='Link start to previous end' openDelay={tooltipDelayMid}>
-            <InputRightElement className={activeStart} onClick={() => handleLink(!linkStart)}>
-              <span className={style.timeLabel}>S</span>
-              <span className={style.fourtyfive}>{linkStart ? <IoLink /> : <IoUnlink />}</span>
-            </InputRightElement>
-          </Tooltip>
+          <InputRightElement>
+            <span className={style.timeLabel}>S</span>
+          </InputRightElement>
         </TimeInputWithButton>
       </div>
 

--- a/apps/client/src/features/rundown/time-input-flow/TimeInputFlow.tsx
+++ b/apps/client/src/features/rundown/time-input-flow/TimeInputFlow.tsx
@@ -56,11 +56,9 @@ function TimeInputFlow(props: EventBlockTimerProps) {
 
   const hasDelay = delay !== 0;
 
-  const isLockedEnd = timeStrategy === TimeStrategy.LockEnd;
   const isLockedDuration = timeStrategy === TimeStrategy.LockDuration;
 
   const activeStart = cx([style.timeAction, linkStart ? style.active : null]);
-  const activeEnd = cx([style.timeAction, isLockedEnd ? style.active : null]);
   const activeDuration = cx([style.timeAction, isLockedDuration ? style.active : null]);
 
   return (
@@ -74,10 +72,16 @@ function TimeInputFlow(props: EventBlockTimerProps) {
           displayTime={displayStart}
           hasDelay={hasDelay}
           placeholder='Start'
-          disabled={!hideEndTime && Boolean(linkStart)}
         >
           {!hideEndTime ? (
-            <Tooltip label='Link start to previous end' openDelay={tooltipDelayMid}>
+            <Tooltip
+              label={
+                linkStart
+                  ? 'Linked — edits stretch the previous event'
+                  : 'Unlinked — independent start (creates a gap)'
+              }
+              openDelay={tooltipDelayMid}
+            >
               <InputRightElement className={activeStart} onClick={() => handleLink(!linkStart)}>
                 <span className={style.timeLabel}>S</span>
                 <span className={style.fourtyfive}>{linkStart ? <IoLink /> : <IoUnlink />}</span>
@@ -100,19 +104,12 @@ function TimeInputFlow(props: EventBlockTimerProps) {
             time={timeEnd}
             displayTime={displayEnd}
             hasDelay={hasDelay}
-            disabled={isLockedDuration}
+            disabled
             placeholder='End'
           >
-            <Tooltip label='Lock end' openDelay={tooltipDelayMid}>
-              <InputRightElement
-                className={activeEnd}
-                onClick={() => handleChangeStrategy(TimeStrategy.LockEnd)}
-                data-testid='lock__end'
-              >
-                <span className={style.timeLabel}>E</span>
-                {isLockedEnd ? <IoLockClosed /> : <IoLockOpenOutline />}
-              </InputRightElement>
-            </Tooltip>
+            <InputRightElement>
+              <span className={style.timeLabel}>E</span>
+            </InputRightElement>
           </TimeInputWithButton>
         </div>
       )}
@@ -123,7 +120,6 @@ function TimeInputFlow(props: EventBlockTimerProps) {
           name='duration'
           submitHandler={handleSubmit}
           time={duration}
-          disabled={!hideEndTime && isLockedEnd}
           placeholder='Duration'
         >
           {!hideEndTime ? (


### PR DESCRIPTION
## Context
Previously Ontime chained events forward: each event's `linkStart` pointed back to the previous event, a linked event's `timeStart` was *derived* from the previous end, and the start input was disabled when linked. This inverts the mental model to **"an event's end flows into the next event's start."**

## Changes
- **`useEventAction.updateTimer`**: editing a **linked** event's start now redirects to the **previous** event — sets its duration so its end lands on the new start (`LockDuration`). The existing forward-cascade engine re-derives the chain, so **no backend change was needed**. Added `getPrevious()` (skips skipped events, matching the server's `getLink`) and refactored `getPreviousEnd()` onto it. Guards against pushing a previous event's end before its own start. Unlinked events / the first event edit their own start (gap behaviour).
- **`TimeInputFlow.tsx`**: start always editable, end **read-only**, `LockEnd` toggle removed, dynamic link tooltip.
- **`IpadTimeInputFlow.tsx`**: link toggle removed (start-stretch still works via the hook).

New events remain linked-by-default via the existing `linkPrevious` setting (default `true`); the server `eventsDefinition` template was intentionally left unchanged to avoid re-linking imported (Excel/JSON) events.

## Verification
- ✅ Server tests pass (107 — rundown-service + parser)
- ✅ Client TypeScript + ESLint clean on touched files
- ⏳ End-to-end browser check pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)